### PR TITLE
Update geonames_postgis_import.md

### DIFF
--- a/docs/geonames_postgis_import.md
+++ b/docs/geonames_postgis_import.md
@@ -34,7 +34,7 @@ create table geoname (
 	geonameid	int,
 	name varchar(200),
 	asciiname varchar(200),
-	alternatenames varchar(10000),
+	alternatenames text,
 	latitude float,
 	longitude float,
 	fclass char(1),


### PR DESCRIPTION
I was having a problem loading the rows where the alternatenames column included no english characters. 
The error was:
DataError: value too long for type character varying(10000)
CONTEXT:  COPY geoname, line 1100, column alternatenames: "Caerwynt,Gorad Vinchehstehr,Ouinchetre,Ouînchêtre,Uinchestr,Uinchester,Vincester,Vinchester,Winche..."

You can replicate by loading GB.txt

Anyways setting the field to text fixes the issue, so I'm creating this pull request if you want to also correct on the main repo