### PR TITLE
geoname.cc2 max length increased to 240

### DIFF
--- a/docs/geonames_postgis_import.md
+++ b/docs/geonames_postgis_import.md
@@ -40,7 +40,7 @@ create table geoname (
 	fclass char(1),
 	fcode varchar(10),
 	country varchar(2),
-	cc2 varchar(60),
+	cc2 varchar(240),
 	admin1 varchar(20),
 	admin2 varchar(80),
 	admin3 varchar(20),


### PR DESCRIPTION
Current max length of cc2 is 170:

```sql
geonames=# SELECT cc2, LENGTH(cc2) FROM geoname WHERE geonameid = 6255146;
                                                                                    cc2                                                                                     | length
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------
 AO,BF,BI,BJ,BW,CD,CF,CG,CI,CM,CV,DJ,DZ,EG,ER,ET,GA,GH,GM,GN,GQ,GW,KE,KM,LR,LS,LY,MA,MG,ML,MR,MU,MW,MZ,NA,NE,NG,RE,RW,SC,SD,SH,SL,SN,SO,SS,ST,SZ,TD,TG,TN,TZ,UG,YT,ZA,ZM,ZW |    170
```

... so increasing limit to 240 is reasonable.